### PR TITLE
File logging

### DIFF
--- a/youtube2zim/constants.py
+++ b/youtube2zim/constants.py
@@ -31,8 +31,21 @@ YOUTUBE_LANG_MAP = {
     "sh": "srp",  # Serbian
 }
 
-logger = getLogger(NAME, level=logging.DEBUG)
+FORMAT = "[%(name)s: %(asctime)s] %(levelname)s: %(message)s"
 
+# create "/output" directory if it doesn't exist yet and write "run.log" file
+log = pathlib.Path("/output").joinpath("run.log")
+log.parent.mkdir(parents=True, exist_ok=True)
+log.touch()
+
+# create logger
+logger = getLogger(
+    NAME,
+    level=logging.DEBUG,
+    file=log,
+    file_format=FORMAT,
+    file_level=logging.DEBUG,
+)
 
 class Youtube:
     def __init__(self):

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -128,6 +128,15 @@ class Youtube2Zim:
             tmp_dir.mkdir(parents=True, exist_ok=True)
         self.build_dir = Path(tempfile.mkdtemp(dir=tmp_dir))
 
+        # logging
+        log =self.output_dir / "run.log"
+        if not log.exists() or log.stat().st_size == 0:
+            with open(log, "a") as f:
+                f.write(f"Log file created at {datetime.datetime.now()}\n")
+        if log.exists() and log.stat().st_size > 0:
+            with open(log, "a") as f:
+                f.write(f"\n\n\nLog for {self.name} started on {datetime.datetime.now()}\n")
+
         # process-related
         self.playlists = []
         self.uploads_playlist_id = None

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -132,10 +132,10 @@ class Youtube2Zim:
         log =self.output_dir / "run.log"
         if not log.exists() or log.stat().st_size == 0:
             with open(log, "a") as f:
-                f.write(f"Log file created at {datetime.datetime.now()}\n")
+                f.write(f"Log file created at {datetime.datetime.now()}\n====================\n")
         if log.exists() and log.stat().st_size > 0:
             with open(log, "a") as f:
-                f.write(f"\n\n\nLog for {self.name} started on {datetime.datetime.now()}\n")
+                f.write(f"\n\n\nLog for {self.name} started on {datetime.datetime.now()}\n====================\n")
 
         # process-related
         self.playlists = []


### PR DESCRIPTION
This feature adds a log file named "run.log" at /output with each run.

The file created is used to store log information about each session that is run.

It also specify in the log which session just ran. This is useful for keeping track of which sessions have been run and for debugging purposes.

To implement this feature, I have enabled a file handler in youtube2zim/constant.py for zimscraperlib logger that writes to the run.log file. The logger formats the log at the beginning and end of each session to mark the start and end of the session in the log file.

I have also added some error handling to ensure that the log file is properly created and written to in case of any issues.

I tested it on Ubuntu 22.10 and 23.04.