### PR TITLE
Custom titles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ zimscraperlib>=1.8.0,<1.9
 requests>=2.26.0,<3.0
 kiwixstorage>=0.8.1,<1.0
 pif==0.8.2
+pytube

--- a/youtube2zim/constants.py
+++ b/youtube2zim/constants.py
@@ -31,8 +31,21 @@ YOUTUBE_LANG_MAP = {
     "sh": "srp",  # Serbian
 }
 
-logger = getLogger(NAME, level=logging.DEBUG)
+FORMAT = "[%(name)s: %(asctime)s] %(levelname)s: %(message)s"
 
+# create "/output" directory if it doesn't exist yet and write "run.log" file
+log = pathlib.Path("/output").joinpath("run.log")
+log.parent.mkdir(parents=True, exist_ok=True)
+log.touch()
+
+# create logger
+logger = getLogger(
+    NAME,
+    level=logging.DEBUG,
+    file=log,
+    file_format=FORMAT,
+    file_level=logging.DEBUG,
+)
 
 class Youtube:
     def __init__(self):

--- a/youtube2zim/entrypoint.py
+++ b/youtube2zim/entrypoint.py
@@ -203,6 +203,14 @@ def main():
         default=False,
         action="store_true",
     )
+    
+    parser.add_argument(
+        "--custom-titles",
+        nargs="+",
+        help="Replace titles with custom titles from text files",
+        default=False,
+        dest="custom_titles",
+    )
 
     args = parser.parse_args()
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -128,6 +128,15 @@ class Youtube2Zim:
             tmp_dir.mkdir(parents=True, exist_ok=True)
         self.build_dir = Path(tempfile.mkdtemp(dir=tmp_dir))
 
+        # logging
+        log =self.output_dir / "run.log"
+        if not log.exists() or log.stat().st_size == 0:
+            with open(log, "a") as f:
+                f.write(f"Log file created at {datetime.datetime.now()}\n")
+        if log.exists() and log.stat().st_size > 0:
+            with open(log, "a") as f:
+                f.write(f"\n\n\nLog for {self.name} started on {datetime.datetime.now()}\n")
+
         # process-related
         self.playlists = []
         self.uploads_playlist_id = None

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -135,10 +135,10 @@ class Youtube2Zim:
         log =self.output_dir / "run.log"
         if not log.exists() or log.stat().st_size == 0:
             with open(log, "a") as f:
-                f.write(f"Log file created at {datetime.datetime.now()}\n")
+                f.write(f"Log file created at {datetime.datetime.now()}\n====================\n")
         if log.exists() and log.stat().st_size > 0:
             with open(log, "a") as f:
-                f.write(f"\n\n\nLog for {self.name} started on {datetime.datetime.now()}\n")
+                f.write(f"\n\n\nLog for {self.name} started on {datetime.datetime.now()}\n====================\n")
 
         # process-related
         self.playlists = []

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -53,6 +53,7 @@ from .youtube import (
     get_channel_json,
     get_videos_authors_info,
     get_videos_json,
+    replace_titles,
     save_channel_branding,
     skip_deleted_videos,
     skip_outofrange_videos,
@@ -84,6 +85,7 @@ class Youtube2Zim:
         dateafter,
         use_any_optimized_version,
         s3_url_with_credentials,
+        custom_titles,
         title=None,
         description=None,
         creator=None,
@@ -120,6 +122,7 @@ class Youtube2Zim:
         self.banner_image = banner_image
         self.main_color = main_color
         self.secondary_color = secondary_color
+        self.custom_titles = custom_titles
 
         # directory setup
         self.output_dir = Path(output_dir).expanduser().resolve()
@@ -481,6 +484,10 @@ class Youtube2Zim:
             for playlist in self.playlists:
                 videos_json = get_videos_json(playlist.playlist_id)
                 # filter in videos within date range and filter away deleted videos
+                # we replace videos titles if --custom-titles is used
+                if self.custom_titles:
+                    replace_titles(videos_json, self.custom_titles)
+                # we filter out videos that are out of range and deleted
                 skip_outofrange = functools.partial(
                     skip_outofrange_videos, self.dateafter
                 )
@@ -965,6 +972,9 @@ class Youtube2Zim:
                 playlist_videos = load_json(
                     self.cache_dir, f"playlist_{playlist.playlist_id}_videos"
                 )
+                # replace video titles if --custom-titles is used
+                if self.custom_titles:
+                    replace_titles(playlist_videos, self.custom_titles)
                 # filtering-out missing ones (deleted or not downloaded)
                 playlist_videos = list(filter(skip_deleted_videos, playlist_videos))
                 playlist_videos = list(filter(is_present, playlist_videos))


### PR DESCRIPTION
This feature allows the user to specify two text files as input when using the --custom-titles option. One of the files should contain a list of video ids, and the other should contain a list of corresponding titles.

The feature includes some checks to ensure that both of these files exist and are properly formatted before attempting to use them. It also includes logging statements to inform the user if any issues are encountered with the files.