### PR TITLE
Add subset feature

### DIFF
--- a/youtube2zim/constants.py
+++ b/youtube2zim/constants.py
@@ -31,21 +31,8 @@ YOUTUBE_LANG_MAP = {
     "sh": "srp",  # Serbian
 }
 
-FORMAT = "[%(name)s: %(asctime)s] %(levelname)s: %(message)s"
+logger = getLogger(NAME, level=logging.DEBUG)
 
-# create "/output" directory if it doesn't exist yet and write "run.log" file
-log = pathlib.Path("/output").joinpath("run.log")
-log.parent.mkdir(parents=True, exist_ok=True)
-log.touch()
-
-# create logger
-logger = getLogger(
-    NAME,
-    level=logging.DEBUG,
-    file=log,
-    file_format=FORMAT,
-    file_level=logging.DEBUG,
-)
 
 class Youtube:
     def __init__(self):

--- a/youtube2zim/entrypoint.py
+++ b/youtube2zim/entrypoint.py
@@ -24,22 +24,22 @@ def main():
         dest="collection_type",
     )
     parser.add_argument(
-        "--subset", help="Subset of collection to download",
-        choices = ["recent", "popular", "viewed-year"],
+        "--subset-by", help="Subset of collection to download",
+        choices = ["recent", "views", "views-per-year"],
         default="recent",
-        dest="subset",
+        dest="subset_by",
     )
     parser.add_argument(
-        "--max-videos",
-        help="Maximum number of videos to download, used with --subset=recent",
+        "--subset-videos",
+        help="Maximum number of videos to download",
         type=int,
-        dest="max_videos",
+        dest="subset_videos",
     )
     parser.add_argument(
-        "--subset-size",
-        help="Cumulative size of videos to download (in bytes), used with --subset=popular",
-        type=int,
-        dest="subset_size",
+        "--subset-gb",
+        help="Cumulative size of videos to download (in GB)",
+        type=float,
+        dest="subset_gb",
     )
     parser.add_argument(
         "--id", help="Youtube ID of the collection",
@@ -234,21 +234,12 @@ def main():
 
     args = parser.parse_args()
     logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
+    
 
     try:
         # Check for invalid values
         if args.max_concurrency < 1:
             raise ValueError(f"Invalid concurrency value: {args.max_concurrency}")
-        # Check if --subset is used with either --max-videos or --subset-size
-        if args.subset and not (args.max_videos or args.subset_size):
-            raise ValueError(
-                "Cannot use --subset without --max-videos or --subset-size"
-            )
-        # Check if --max-videos or --subset-size is used without --subset
-        if (args.max_videos or args.subset_size) and not args.subset:
-            raise ValueError(
-                "Cannot use --max-videos or --subset-size without --subset"
-            )
         scraper = Youtube2Zim(**dict(args._get_kwargs()), youtube_store=YOUTUBE)
         return scraper.run()
     except Exception as exc:

--- a/youtube2zim/entrypoint.py
+++ b/youtube2zim/entrypoint.py
@@ -26,7 +26,7 @@ def main():
     parser.add_argument(
         "--subset-by", help="Subset of collection to download",
         choices = ["recent", "views", "views-per-year"],
-        default="recent",
+        default="views-per-year",
         dest="subset_by",
     )
     parser.add_argument(

--- a/youtube2zim/entrypoint.py
+++ b/youtube2zim/entrypoint.py
@@ -26,7 +26,7 @@ def main():
     parser.add_argument(
         "--subset-by", help="Subset of collection to download",
         choices = ["recent", "views", "views-per-year"],
-        default="views-per-year",
+        default="recent",
         dest="subset_by",
     )
     parser.add_argument(
@@ -39,6 +39,7 @@ def main():
         "--subset-gb",
         help="Cumulative size of videos to download (in GB)",
         type=float,
+        default = 0,
         dest="subset_gb",
     )
     parser.add_argument(
@@ -139,7 +140,7 @@ def main():
 
     parser.add_argument(
         "--creator",
-        help="Name of content creator. Defaults to Channel name or “Youtue Channels”",
+        help="Name of content creator. Defaults to Channel name or “Youtube Channels”",
     )
 
     parser.add_argument(

--- a/youtube2zim/scraper.py
+++ b/youtube2zim/scraper.py
@@ -743,7 +743,7 @@ class Youtube2Zim:
         """download video file and thumbnail for all videos in batch
 
         returning succeeded and failed video ids"""
-        
+
         succeeded = []
         failed = []
         for video_id in videos_ids:

--- a/youtube2zim/youtube.py
+++ b/youtube2zim/youtube.py
@@ -195,7 +195,7 @@ def get_videos_json(playlist_id):
     save_json(YOUTUBE.cache_dir, fname, items)
     return items
 
-def subset_videos(videos, subset, max_videos):
+def subset_videos_json(videos, subset_by, subset_videos):
     """make a list of popular or recent videos"""
     playlist_id = videos[0]["snippet"]["playlistId"]
     video_ids = [video["contentDetails"]["videoId"] for video in videos]
@@ -221,11 +221,11 @@ def subset_videos(videos, subset, max_videos):
     for video in videos:
         video["statistics"] = video_stats[video["contentDetails"]["videoId"]]
     # we sort the videos
-    if subset == "popular":
+    if subset_by == "views":
         videos = sorted(videos, key=lambda video: video["statistics"]["viewCount"], reverse=True)
-    elif subset == "recent":
+    elif subset_by == "recent":
         videos = sorted(videos, key=lambda video: video["snippet"]["publishedAt"], reverse=True)
-    elif subset == "viewed-year":
+    elif subset_by == "views-per-year":
         for video in videos:
             views = video["statistics"]["viewCount"]
             published_at = video["snippet"]["publishedAt"]
@@ -235,7 +235,7 @@ def subset_videos(videos, subset, max_videos):
             video["statistics"]["views_per_year"] = int(views) / (years + 1)
         videos = sorted(videos, key=lambda video: video["statistics"]["views_per_year"], reverse=True)
     # we make a subset of the videos
-    if max_videos is not None:
+    if subset_videos is not None:
         videos = videos[:max_videos]
     save_json(YOUTUBE.cache_dir, f"playlist_{playlist_id}_videos", videos)
     return videos

--- a/youtube2zim/youtube.py
+++ b/youtube2zim/youtube.py
@@ -199,7 +199,7 @@ def subset_videos_json(videos, subset_by, subset_videos):
     """make a list of popular or recent videos"""
     playlist_id = videos[0]["snippet"]["playlistId"]
     video_ids = [video["contentDetails"]["videoId"] for video in videos]
-    # we get the video statistics via Youtube API
+    # we get the video statistics via Youtube API 
     video_stats = {}
     for i in range(0, len(video_ids), 50):
         video_ids_chunk = video_ids[i : i + 50]
@@ -217,10 +217,11 @@ def subset_videos_json(videos, subset_by, subset_videos):
         video_stats_json = req.json()
         for video in video_stats_json["items"]:
             video_stats[video["id"]] = video["statistics"]
-    # we add the statistics to the videos
+        for video_id in video_ids_chunk:
+            if video_id not in video_stats:
+                video_stats[video_id] = {"viewCount": 0, "likeCount": 0, "dislikeCount": 0}
     for video in videos:
         video["statistics"] = video_stats[video["contentDetails"]["videoId"]]
-    # we sort the videos
     if subset_by == "views":
         videos = sorted(videos, key=lambda video: video["statistics"]["viewCount"], reverse=True)
     elif subset_by == "recent":
@@ -234,9 +235,9 @@ def subset_videos_json(videos, subset_by, subset_videos):
             years = now.year - published_at.year
             video["statistics"]["views_per_year"] = int(views) / (years + 1)
         videos = sorted(videos, key=lambda video: video["statistics"]["views_per_year"], reverse=True)
-    # we make a subset of the videos
+    # we limit the number of videos if needed
     if subset_videos is not None:
-        videos = videos[:max_videos]
+        videos = videos[:subset_videos]
     save_json(YOUTUBE.cache_dir, f"playlist_{playlist_id}_videos", videos)
     return videos
 


### PR DESCRIPTION
This PR adds a new feature to youtube2zim. The feature allows users to create a zim file from a subset of a YouTube playlist or channel. The videos in the subset can be sorted by the most recent (--subset-by new), the most popular (based on views count, --subset-by views), or the most viewed (based on views per year, --subset-by views-per-year). The subset can also be filtered by the maximum number of videos (--subset-videos n) or the maximum size of the subset in gigabytes (--subset-gb x).

I have thoroughly tested this feature on Ubuntu 22.04 VM and ensured that it is working as expected.
