### PR TITLE
Fix error on unordered ids

### DIFF
--- a/youtube2zim/youtube.py
+++ b/youtube2zim/youtube.py
@@ -246,10 +246,15 @@ def replace_titles(items, custom_titles):
     v_index = 0
     for item in items:
         if v_index < len(ids):
-            if item["contentDetails"]["videoId"] == ids[v_index]:
+            while v_index < len(ids) and item["contentDetails"]["videoId"] != ids[v_index]:
+                v_index += 1
+            if v_index < len(ids):
                 logger.info(f"replacing {item['snippet']['title']} with {titles[v_index]}")
                 item["snippet"]["title"] = titles[v_index]
                 v_index += 1
+        else:
+            logger.debug(f"no more titles to replace")
+            break
 
 
 def get_videos_authors_info(videos_ids):


### PR DESCRIPTION
This PR ensure the titles replacement loop doesn't break in case the video IDs are not in the same order as the titles.